### PR TITLE
Codesign on Github Actions

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -54,6 +54,22 @@ jobs:
           security import certificate.p12 -k build.keychain -P "${APPLEDEV_CERT_PHRASE}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PW}" build.keychain
           /usr/bin/codesign --force -s "${CODESIGN_ID}" Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle -v
+      - name: Notarize Mailbundle
+        uses: devbotsxyz/xcode-notarize@v1
+        env:
+          CODESIGN_ID: ${{ secrets.CODESIGN_ID }}
+        if : env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
+        with:
+          product-path: Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle
+          appstore-connect-username: ${{ secrets.APPLE_NOTARIZE_ID }}
+          appstore-connect-password: ${{ secrets.APPLE_NOTARIZE_PW }}
+      - name: Staple notarization ticket to mailbundle
+        uses: devbotsxyz/xcode-staple@v1
+        if : env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
+        with:
+          product-path: Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle
+          verbose: True
+
       - name: Upload mailbundle
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -28,13 +28,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Make
+
+      - name: Build mailbundle
         working-directory: Source
         run: |
           export COMMIT_HASH=${GITHUB_SHA:0:7}
           export BUILD_NUMBER=$(( $(date +"%s") / 3600 - 262968 ))
           export BUILD_VERSION=${BUILD_NUMBER}.${GITHUB_RUN_NUMBER}
           make ${{ matrix.gpgmail }}
+
+      - name: Codesign mailbundle
+        # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
+        env:
+          APPLEDEV_CERT: ${{ secrets.APPLEDEV_CERT }}
+          APPLEDEV_CERT_PHRASE: ${{ secrets.APPLEDEV_CERT_PHRASE }}
+          CODESIGN_ID: ${{ secrets.CODESIGN_ID }}
+          KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
+        # only accessible for PRs from the unforked repository
+        if : env.CODESIGN_ID != ''
+        run: |
+          base64 --decode > certificate.p12 <<< "${APPLEDEV_CERT}"
+          security create-keychain -p "${KEYCHAIN_PW}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${KEYCHAIN_PW}" build.keychain
+          security import certificate.p12 -k build.keychain -P "${APPLEDEV_CERT_PHRASE}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PW}" build.keychain
+          /usr/bin/codesign --force -s "${CODESIGN_ID}" Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle -v
       - name: Upload mailbundle
         uses: actions/upload-artifact@v2
         with:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -69,8 +69,10 @@ Installation
         mkdir -p ~/Library/Mail/Bundles/
         cp -r Free-GPGMail_5.mailbundle ~/Library/Mail/Bundles/
 
-4. On macOS 11.0 Big Sur and later, add a Gatekeeper rule to allow the custom
-   mailbundle
+4. Add a Gatekeeper rule to allow the custom mailbundle \
+   *(This is only necessary for custom builds from source on macOS 11 Big Sur
+   or later. Our [released mailbundles ](../../releases/) are now properly signed
+   and notarized)*
 
         sudo spctl --add ~/Library/Mail/Bundles/Free-GPGMail_5.mailbundle
 


### PR DESCRIPTION
I finally managed to load a developer certificate into Github Actions and use it for signing the mailbundle and submit it to Apple for notarization.