### PR TITLE
Add 12.3 UUID

### DIFF
--- a/Source/GPGMail_6/Resources/Info.plist
+++ b/Source/GPGMail_6/Resources/Info.plist
@@ -53,15 +53,5 @@
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
 		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
-	<key>Supported12.4PluginCompatibilityUUIDs</key>
-	<array>
-		<string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
-		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
-	</array>
-	<key>Supported12.5PluginCompatibilityUUIDs</key>
-	<array>
-		<string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
-		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
-	</array>
 </dict>
 </plist>

--- a/Source/GPGMail_6/Resources/Info.plist
+++ b/Source/GPGMail_6/Resources/Info.plist
@@ -51,6 +51,7 @@
 	<array>
 		<string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.4PluginCompatibilityUUIDs</key>
 	<array>


### PR DESCRIPTION
This adds support for Monterey 12.3

We are still on 2021.3 though.