### PR TITLE
signed/unsigned GM5 bundle

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -15,14 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        gpgmail: [GPGMail_3, GPGMail_4, GPGMail_5, GPGMail_6]
         os: [macos-latest]
-        gpgmail: [GPGMail_3, GPGMail_4]
-        include:
-          - os: macos-11
-            gpgmail: GPGMail_5
-          - os: macos-11
-            gpgmail: GPGMail_6
-
 
     steps:
       - uses: actions/checkout@v2
@@ -43,7 +37,7 @@ jobs:
           CODESIGN_ID: ${{ secrets.CODESIGN_ID }}
           KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
         # only accessible for PRs from the unforked repository
-        if : env.CODESIGN_ID != ''
+        if:  env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
         run: |
           base64 --decode > certificate.p12 <<< "${APPLEDEV_CERT}"
           security create-keychain -p "${KEYCHAIN_PW}" build.keychain
@@ -51,14 +45,15 @@ jobs:
           security unlock-keychain -p "${KEYCHAIN_PW}" build.keychain
           security import certificate.p12 -k build.keychain -P "${APPLEDEV_CERT_PHRASE}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PW}" build.keychain
-          /usr/bin/codesign --force -s "${CODESIGN_ID}" Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle -v
+          cp -r Source/bundles Source/bundles_signed
+          /usr/bin/codesign --force -s "${CODESIGN_ID}" Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle -v
       - name: Notarize Mailbundle
         uses: devbotsxyz/xcode-notarize@v1
         env:
           CODESIGN_ID: ${{ secrets.CODESIGN_ID }}
         if : env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
         with:
-          product-path: Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle
+          product-path: Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle
           appstore-connect-username: ${{ secrets.APPLE_NOTARIZE_ID }}
           appstore-connect-password: ${{ secrets.APPLE_NOTARIZE_PW }}
       - name: Staple notarization ticket to mailbundle
@@ -67,7 +62,7 @@ jobs:
           CODESIGN_ID: ${{ secrets.CODESIGN_ID }}
         if : env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
         with:
-          product-path: Source/bundles/Free-${{ matrix.gpgmail }}.mailbundle
+          product-path: Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle
           verbose: True
 
       - name: Upload mailbundle
@@ -75,6 +70,13 @@ jobs:
         with:
           name: Free-${{ matrix.gpgmail }}.mailbundle
           path: Source/bundles/
+
+      - name: Upload mailbundle signed
+        uses: actions/upload-artifact@v2
+        if:  env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
+        with:
+          name: Free-${{ matrix.gpgmail }}_signed.mailbundle
+          path: Source/bundles_signed/
 
       - name: Upload mailbundle debuginfo
         uses: actions/upload-artifact@v2

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,6 +29,18 @@ jobs:
           export BUILD_VERSION=${BUILD_NUMBER}.${GITHUB_RUN_NUMBER}
           make ${{ matrix.gpgmail }}
 
+      - name: Upload mailbundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: Free-${{ matrix.gpgmail }}.mailbundle
+          path: Source/bundles/
+
+      - name: Upload mailbundle debuginfo
+        uses: actions/upload-artifact@v2
+        with:
+          name: Free-${{ matrix.gpgmail }}.mailbundle.dSYM
+          path: Source/${{ matrix.gpgmail }}/build/Release/Free-GPGMail.mailbundle.dSYM
+
       - name: Codesign mailbundle
         # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
         env:
@@ -47,6 +59,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PW}" build.keychain
           cp -r Source/bundles Source/bundles_signed
           /usr/bin/codesign --force -s "${CODESIGN_ID}" Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle -v
+      
       - name: Notarize Mailbundle
         uses: devbotsxyz/xcode-notarize@v1
         env:
@@ -56,6 +69,7 @@ jobs:
           product-path: Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle
           appstore-connect-username: ${{ secrets.APPLE_NOTARIZE_ID }}
           appstore-connect-password: ${{ secrets.APPLE_NOTARIZE_PW }}
+      
       - name: Staple notarization ticket to mailbundle
         uses: devbotsxyz/xcode-staple@v1
         env:
@@ -65,21 +79,9 @@ jobs:
           product-path: Source/bundles_signed/Free-${{ matrix.gpgmail }}.mailbundle
           verbose: True
 
-      - name: Upload mailbundle
-        uses: actions/upload-artifact@v2
-        with:
-          name: Free-${{ matrix.gpgmail }}.mailbundle
-          path: Source/bundles/
-
-      - name: Upload mailbundle signed
+      - name: Upload signed mailbundle
         uses: actions/upload-artifact@v2
         if:  env.CODESIGN_ID != '' && ! (endsWith(matrix.gpgmail, '3') || endsWith(matrix.gpgmail, '4'))
         with:
           name: Free-${{ matrix.gpgmail }}_signed.mailbundle
           path: Source/bundles_signed/
-
-      - name: Upload mailbundle debuginfo
-        uses: actions/upload-artifact@v2
-        with:
-          name: Free-${{ matrix.gpgmail }}.mailbundle.dSYM
-          path: Source/${{ matrix.gpgmail }}/build/Release/Free-GPGMail.mailbundle.dSYM

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,13 +23,17 @@ or promotion of our releases by the intermediate copyright holders.
 Depending on supported macOS versions, there are different versions of
 the plugin available:
 
-| Mailbundle     | 10.13       | 10.14  | 10.15    | 11      | 12       |
-| -------------- | ----------- | ------ | -------- | --------| -------- |
-|                | High Sierra | Mojave | Catalina | Big Sur | Monterey |
-| Free-GPGMail 3 | x           | x      |          |         |          |
-| Free-GPGMail 4 | x           | x      | x        |         |          |
-| Free-GPGMail 5 |             | x      | x        | x       |          |
-| Free-GPGMail 6 |             |        |          |         | x        |
+| Mailbundle      | 10.13       | 10.14  | 10.15    | 11      | 12       |
+| --------------  | ----------- | ------ | -------- | --------| -------- |
+|                 | High Sierra | Mojave | Catalina | Big Sur | Monterey |
+| Free-GPGMail 3  | x           | x      |          |         |          |
+| Free-GPGMail 4  | x           | x      | x        |         |          |
+| Free-GPGMail 5* |             | u      | u        | s       |          |
+| Free-GPGMail 6  |             |        |          |         | x        |
+
+(*) While Big Sur requires Free-GPGMail 5 to be codesigned, Mojave and Catalina
+do not like the code signature of the provided mailbundles. Thus, we publish
+an unsigned and a signed version of the Free-GPGMail 5 mailbundle.
 
 Note that GnuPG and Libmacgpg must be installed first and then the mailbundle
 binaries can be activated. You can compile them from source or install them


### PR DESCRIPTION
Save an unsigned Free-GPGMail_5 mailbundle artifact in order to provide it for Mojave and Catalina (For #40)