### PR TITLE
Updated README for MacOS 12.5+ and Mail16+.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -106,7 +106,6 @@ Installation
    - Enable the `Free-GPGMail_<version>.mailbundle`.
    - **Apply and Restart Mail**.
 
-
 3. In Mail.app, check `Preferences -> Free-GPGMail`. If it says that you are in
    **Trial Mode** or **Decryption Only Mode**, hit **Activate**. It will perform
    a dummy activation routine.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -71,6 +71,11 @@ Installation
       ```bash
       brew install --cask free-gpgmail
       ```
+
+      If you receive an error mkdir: `/Users/YOUR_USERNAME/Library/Mail/Bundles: Operation not permitted`,
+      open the Security & Privacy system preference panel, and grant "Full Disk
+      Access" to terminal. Retry the installation.
+
     - or manually:
         1. Download and install the GPG Suite .dmg file from the commercial seller or from the
            [Free-GPGMail releases page](../../releases/).
@@ -87,9 +92,20 @@ Installation
            visibility in "Show View Options" while you are in **Home**)
 
 2. Restart Mail.app, go to `Preferences -> General -> Manage Plugins...`.
+    
+    If the "Manage Plugins" button is not present in the lower left corner,
+    open a terminal and run:
+    ```bash
+    sudo defaults write “/Library/Preferences/com.apple.mail” EnableBundles 1
+    defaults write com.apple.mail EnableBundles -bool true
+    ```
+    
+    Then restart Mail.app again.
+
    - Make sure that `GPGMailLoader_*.mailbundle`, if present, is disabled.     
    - Enable the `Free-GPGMail_<version>.mailbundle`.
    - **Apply and Restart Mail**.
+
 
 3. In Mail.app, check `Preferences -> Free-GPGMail`. If it says that you are in
    **Trial Mode** or **Decryption Only Mode**, hit **Activate**. It will perform


### PR DESCRIPTION
I have updated the Readme to now include steps for: 

1. Granting full disk access for terminal if installing via brew as a work-around for issue #53, and 
2. How to enable the manage plugins button in Mail.app if this is not present (as it was not by default for me on MacOS 12.5.1 with Mail.app 16.0).