### PR TITLE
Fix link to Homebrew Cask

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -77,7 +77,7 @@ Installation
       open the Security & Privacy system preference panel, and grant "Full Disk
       Access" to terminal. Retry the installation.
       
-      Note that the [homebrew cask for free-gpgmail](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/free-gpgmail.rb)
+      Note that the [homebrew cask for free-gpgmail](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/f/free-gpgmail.rb)
       is maintained in a different repository and has some
       [issues with updating from old versions](https://github.com/Free-GPGMail/Free-GPGMail/issues/81).
       


### PR DESCRIPTION
The directory structure of Casks has changed. This PR updates the link in the README to point to the correct file again.